### PR TITLE
Improved Tab styles

### DIFF
--- a/app/components/app/App.css
+++ b/app/components/app/App.css
@@ -45,6 +45,18 @@ body {
     background-color: #313131;
 }
 
+.nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus {
+    color: whitesmoke;
+    background-color: #5A180C;
+    border: none;
+}
+
+.nav-tabs > li > a:hover {
+    background-color: #5A180C;
+    border-color: transparent;
+    border-bottom-color: #ddd;
+}
+
 .header-image {
     height: 550px;
     background-image: url('https://walter.trakt.us/images/shows/000/001/390/fanarts/original/76d5df8aed.jpg');

--- a/app/components/app/App.css
+++ b/app/components/app/App.css
@@ -45,6 +45,10 @@ body {
     background-color: #313131;
 }
 
+.nav-tabs > li > a {
+    font-family: 'Cinzel Decorative', cursive;
+}
+
 .nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus {
     color: whitesmoke;
     background-color: #5A180C;


### PR DESCRIPTION
<img width="804" alt="screen shot 2016-03-20 at 23 41 59" src="https://cloud.githubusercontent.com/assets/3121306/13907736/6b7c7cac-eef5-11e5-9479-883ed113b6fe.png">

Make tabs use our color scheme. 
Any thoughts? @jorjo1 
