### PR TITLE
Remove all those ugly and unneeded fields from the pagination

### DIFF
--- a/app/components/app/App.css
+++ b/app/components/app/App.css
@@ -73,7 +73,9 @@ body {
 
 .pagination > li > a:hover, .pagination > li > span:hover, .pagination > li > a:focus, .pagination > li > span:focus,
 .pagination > li > a, .pagination > li > span {
-    color: #5A180C;
+    color: whitesmoke;
+    background-color: #333;
+    border: none;
 }
 
 

--- a/app/components/app/App.css
+++ b/app/components/app/App.css
@@ -40,7 +40,8 @@ body {
     /*z-index: -1; !* Make sure the image sits below the content *! */
 /*}*/
 
-.tab-pane{
+/* Tabs */
+.tab-pane {
     padding: 15px;
     background-color: #313131;
 }
@@ -60,6 +61,21 @@ body {
     border-color: transparent;
     border-bottom-color: #ddd;
 }
+
+/* Pagination */
+.pagination > .active > a, .pagination > .active > span, .pagination > .active > a:hover, .pagination > .active > span:hover, .pagination > .active > a:focus, .pagination > .active > span:focus {
+    z-index: 3;
+    color: #fff;
+    cursor: default;
+    background-color: #5A180C;
+    border-color: #5A180C;
+}
+
+.pagination > li > a:hover, .pagination > li > span:hover, .pagination > li > a:focus, .pagination > li > span:focus,
+.pagination > li > a, .pagination > li > span {
+    color: #5A180C;
+}
+
 
 .header-image {
     height: 550px;

--- a/app/components/public/CharacterList/CharacterList.jsx
+++ b/app/components/public/CharacterList/CharacterList.jsx
@@ -71,14 +71,10 @@ export default class CharacterListPage extends Component {
           <CharacterList data={this.state.data} />
           <div className="center">
             <Pagination
-              prev
-              next
-              first
-              last
-              ellipsis
+              maxButtons={3}
+              ellipsis={false}
               boundaryLinks
               items={Math.ceil(Store.getCharactersCount()/20)}
-              maxButtons={5}
               activePage={this.state.activePage}
               onSelect={this.handleSelect.bind(this)} />
             </div>


### PR DESCRIPTION
<img width="846" alt="screen shot 2016-03-20 at 23 57 04" src="https://cloud.githubusercontent.com/assets/3121306/13907846/878bf470-eef7-11e5-8675-fddabd6f0551.png">

VS.

<img width="806" alt="screen shot 2016-03-20 at 23 58 36" src="https://cloud.githubusercontent.com/assets/3121306/13907858/b1bcb4b4-eef7-11e5-8e85-e10a5364282a.png">

1 or 2 @yashha @jorjo1 ?
