### PR TITLE
Scroll to top on page change

### DIFF
--- a/app/main.jsx
+++ b/app/main.jsx
@@ -36,7 +36,7 @@ browserHistory.listen(location => {
 });
 
 ReactDOM.render(
-  <Router history={browserHistory}>
+  <Router onUpdate={() => window.scrollTo(0, 0)} history={browserHistory}>
     <Route path="/" component={App}>
       <IndexRoute component={Start}/>
       <Route path="/ranking" component={Ranking}/>


### PR DESCRIPTION
Previously:
- You're at /ranking, scrolled down a bit, and clicked on "see more" survivors
- You're linked to the characters page, which is scrolled down the same distance as the ranking page previously

Now:
- When you change pages you always will land on top of that page. :tada: 

(PS: That's what @gyachdav mentioned some time ago, and @sacdallago and we said it's a feature not a bug^^)
