### PR TITLE
Don't justify headlines

### DIFF
--- a/app/components/app/App.css
+++ b/app/components/app/App.css
@@ -13,6 +13,7 @@ body {
 h1,h2,h3,h4,h5,
 title {
     font-family: 'Cinzel Decorative', cursive;
+    text-align: left;
 }
 
 a {


### PR DESCRIPTION
Headlines should not be justified, like our paragraphs.
Before:
<img width="932" alt="screen shot 2016-04-11 at 21 13 24" src="https://cloud.githubusercontent.com/assets/3121306/14439243/7d90623c-002a-11e6-814e-83295db48fd5.png">

After:
<img width="918" alt="screen shot 2016-04-11 at 21 13 28" src="https://cloud.githubusercontent.com/assets/3121306/14439252/8466d848-002a-11e6-948e-bd7a4f462d8a.png">
