### PR TITLE
Home statistics link & Fixes on statistics page

### DIFF
--- a/app/components/public/Start/Start.jsx
+++ b/app/components/public/Start/Start.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 let {Component} = React;
 import { Row,Col, Grid } from 'react-bootstrap';
+import { Link } from 'react-router';
 import AntagonistsComp from '../../common/AntagonistsComp/AntagonistsComp.jsx';
 import './Start.css';
 import logo from './gotstatslogosmall.jpg';
@@ -25,12 +26,12 @@ export default class Start extends Component {
 
           <Row className="stats-home">
             <Col xs={10} xsOffset={1} sm={3} smOffset={1}>
-              <img src={logo} className="start-logo" />
+              <Link to={"/statistics"}><img src={logo} className="start-logo" /></Link>
             </Col>
             <Col xs={10} xsOffset={1} sm={6} smOffset={1}>
-              <h1>Life, death and statistics in Westeros</h1>
+              <Link to={"/statistics"}><h1>Life, death and statistics in Westeros</h1></Link>
               <p className="lead">While we all wait for the Winds of Winter to come out, we figured that it will be pretty cool
-              to design some machine learning algorithm that will answer the question that is on every Game of Thrones’ fan mind - which character is likelier to die next?</p>
+              to design some machine learning algorithm that will answer the question that is on every Game of Thrones’ fan mind - which character is likelier to die next? <Link to={"/statistics"}>Read more</Link></p>
             </Col>
           </Row>
 

--- a/app/components/public/Statistics/src.js
+++ b/app/components/public/Statistics/src.js
@@ -39,7 +39,8 @@ function drawNewCharactersIntroduced() {
         color: '#AAAAAA'
       },
       textStyle: {
-        fontSize: 17
+        fontSize: 17,
+        color: '#AAAAAA'
       },
     },
     vAxis: {

--- a/app/components/public/Statistics/src.js
+++ b/app/components/public/Statistics/src.js
@@ -16,7 +16,6 @@ function drawNewCharactersIntroduced() {
   var chart = new google.visualization.BarChart(document.getElementById('new_characters_introduced'));
 
   var options = {
-    width: '100%',
     height: 400,
     colors: ['#2196f3', '#f44336'],
     backgroundColor: '#1F1F1F',
@@ -126,7 +125,6 @@ function drawCharactersPerEpisode() {
         color: '#AAAAAA'
       }
     },
-    width: 1000,
     height: 400,
     pointSize: 7,
     colors: ['#2196f3', '#f44336'],
@@ -179,7 +177,6 @@ function drawDeadAndAlive() {
   var chart = new google.visualization.BarChart(document.getElementById('dead_and_alive'));
 
   var options = {
-    width: 600,
     height: 400,
     colors: ['#2196f3', '#f44336'],
     backgroundColor: '#1F1F1F',
@@ -342,7 +339,6 @@ function drawDistributionPLODs() {
     [100, 0, null, 0, null]
   ]);
   var options = {
-    width: 600,
     height: 400,
     colors: ['#2196f3', '#f44336'],
     backgroundColor: '#1F1F1F',
@@ -498,7 +494,6 @@ function drawDistributionNoblesPLODs() {
     [100, 0, 0]
   ]);
   var options = {
-    width: 600,
     height: 400,
     lineWidth: 3,
     colors: ['#2196f3', '#f44336'],
@@ -563,7 +558,6 @@ function drawDistributionPLODsAgeDistribution() {
     ['91-100', 19]
   ]);
   var options = {
-    width: 600,
     height: 400,
     colors: ['#2196f3'],
     backgroundColor: '#1F1F1F',
@@ -669,7 +663,6 @@ function drawAvgPLODPerEpisode() {
     legend: {
       position: 'none'
     },
-    width: 1000,
     height: 400,
     colors: ['#2196f3'],
     backgroundColor: '#1F1F1F',


### PR DESCRIPTION
- On the homepage the following links to the statistics-page: GoT-Stats Logo, _Life, death and statistics in Westeros_, a new Read More link
- On the statistic page I fixed the color on the h-axis of the first graph
- On the statistics page I tried to center the graphs, by removing their fixed width. It looks like this:
  <img width="865" alt="screen shot 2016-04-15 at 18 41 54" src="https://cloud.githubusercontent.com/assets/3121306/14568647/74ed9560-033a-11e6-815a-fd2856eb1b97.png">
  At the first glimpse I guess now the graph is centered, but not the whole container including its legend etc. 
  I think this is a good enough fix.

Closes #441
