### PR TITLE
Fix title overlapping image on characters-listing

### DIFF
--- a/app/components/common/CharacterThumbnail/CharacterThumbnail.css
+++ b/app/components/common/CharacterThumbnail/CharacterThumbnail.css
@@ -21,7 +21,8 @@
 
 .thumbnail .caption {
 	color: whitesmoke;
-    padding: 0 9px;
+    line-height: 1em;
+    padding: 0 20px;
     text-align: center;
     position: absolute;
     bottom: 10%;


### PR DESCRIPTION
Before:
![31d3195a-01ad-11e6-9735-42ccb96b1efa](https://cloud.githubusercontent.com/assets/3121306/14568811/856f3c44-033b-11e6-8c03-40dd62d5313d.png)

After:
<img width="179" alt="screen shot 2016-04-15 at 18 50 52" src="https://cloud.githubusercontent.com/assets/3121306/14568788/6346df28-033b-11e6-977f-46461302ccf9.png">

Done via making the line-height smaller. I also added more padding so the title isn't overflowing the whole thumbnail-container on mobile.

Closes #424
