### PR TITLE
Center rostlab logo

### DIFF
--- a/app/components/app/Footer/Footer.jsx
+++ b/app/components/app/Footer/Footer.jsx
@@ -97,9 +97,9 @@ export default class Footer extends Component {
               </Col>
             </Row>
             <Row>
-              <Col xs={10} xsOffset={1} sm={6} smOffset={3}>
+              <div className="text-center">
                 <a href="https://rostlab.org"><Image src={rostlab} className="footerlogo"/></a>
-              </Col>
+              </div>  
             </Row>
           </div>
         </footer>


### PR DESCRIPTION
Looks like someone didn't change the columns after removing the old TUM logo next to the rostlab one. Let's use bootstraps css class to center the image
